### PR TITLE
Add Feature: Edit Study Groups Names

### DIFF
--- a/client/app/api/studygroup.js
+++ b/client/app/api/studygroup.js
@@ -13,3 +13,5 @@ export const getStudyGroups = ({ email }) => StudyGroupClient.get(`/${email}`);
 export const createStudyGroup = (studyGroupData) => StudyGroupClient.post('/', studyGroupData);
 
 export const deleteStudyGroup = (studyGroupId) => StudyGroupClient.delete(`/id/${studyGroupId}`);
+
+export const editStudyGroupName = (id, newName) => StudyGroupClient.patch(`/editName/${id}`, newName );

--- a/client/app/messages.js
+++ b/client/app/messages.js
@@ -103,6 +103,10 @@ export default function Messages() {
                             <TouchableOpacity onPress={() => handleDeleteGroup(item._id)}>
                                 <Text style={styles.deleteText}>Delete</Text>
                             </TouchableOpacity>
+                            {/* Delete Button */}
+                            <TouchableOpacity onPress={() => handleDeleteGroup(item._id)}>
+                                <Text style={styles.editText}>Edit Name</Text>
+                            </TouchableOpacity>
                         </View>
                     )}
                 />
@@ -219,7 +223,19 @@ const styles = StyleSheet.create({
     },
     deleteText: {
         color: 'red',
+        backgroundColor: 'grey',
         fontSize: 18,
+        borderRadius: 5,
+        borderWidth: 2,
+        width: '10%',
+    },
+    editText: {
+        fontSize: 18,
+        borderRadius: 5,
+        backgroundColor: 'grey',
+        marginVertical: 1,
+        borderWidth: 2,
+        width: '10%',
     }
 });
 

--- a/server/controllers/studyGroupController.js
+++ b/server/controllers/studyGroupController.js
@@ -67,7 +67,10 @@ export const editStudyGroupName = async (req, res) => {
 
     // Check if the name was provided
     if (!name) {
-        return res.status(400).json({ message: 'Group name is required' });
+        return res.status(400).json({
+            message: 'Group name is required',
+            errorDetails: 'The request did not include a name for the group.'
+        });
     }
 
     try {
@@ -75,11 +78,24 @@ export const editStudyGroupName = async (req, res) => {
         const updatedGroup = await StudyGroup.findByIdAndUpdate(id, { name }, { new: true });
 
         if (!updatedGroup) {
-            return res.status(404).json({ message: 'Study group not found' });
+            return res.status(404).json({
+                message: 'Study group not found',
+                errorDetails: `No study group found with the id: ${id}.`
+            });
         }
 
-        res.status(200).json({ message: 'Study group name updated successfully', group: updatedGroup });
+        res.status(200).json({
+            message: 'Study group name updated successfully',
+            group: updatedGroup
+        });
     } catch (e) {
-        res.status(500).json({ message: 'Server error', error: e.message });
+        // Log the error for debugging
+        console.error('Error updating study group:', e);
+
+        res.status(500).json({
+            message: 'Server error occurred while updating the study group',
+            errorDetails: `The error occurred while trying to update the group with id: ${id}. Error: ${e.message}`,
+            errorStack: e.stack
+        });
     }
 };

--- a/server/controllers/studyGroupController.js
+++ b/server/controllers/studyGroupController.js
@@ -59,3 +59,27 @@ export const deleteStudyGroup = async (req, res) => {
         res.status(500).json({ message: 'Server error', error: e.message });
     }
 };
+
+// New function to edit the name of a study group
+export const editStudyGroupName = async (req, res) => {
+    const { id } = req.params; // Get group ID from request parameters
+    const { name } = req.body; // Get the new group name from request body
+
+    // Check if the name was provided
+    if (!name) {
+        return res.status(400).json({ message: 'Group name is required' });
+    }
+
+    try {
+        // Attempt to find and update the Study Group by id
+        const updatedGroup = await StudyGroup.findByIdAndUpdate(id, { name }, { new: true });
+
+        if (!updatedGroup) {
+            return res.status(404).json({ message: 'Study group not found' });
+        }
+
+        res.status(200).json({ message: 'Study group name updated successfully', group: updatedGroup });
+    } catch (e) {
+        res.status(500).json({ message: 'Server error', error: e.message });
+    }
+};

--- a/server/routes/studyGroupRoutes.js
+++ b/server/routes/studyGroupRoutes.js
@@ -1,9 +1,15 @@
 import express from 'express';
-import {getGroups, createStudyGroup, deleteStudyGroup} from '../controllers/studyGroupController.js';
+import {
+    getGroups,
+    createStudyGroup,
+    deleteStudyGroup,
+    editStudyGroupName
+} from '../controllers/studyGroupController.js';
 
 const router = express.Router();
 
 router.get('/:email', getGroups);
 router.post('/', createStudyGroup);
 router.delete('/id/:id', deleteStudyGroup);
+router.patch('/editName/:id',editStudyGroupName); //Editing is done by the group id
 export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -9,7 +9,7 @@ const app = express()
 app.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', 'http://localhost:8081');
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
-    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
     res.header('Access-Control-Allow-Credentials', 'true');
     if (req.method === 'OPTIONS') {
         return res.sendStatus(200);


### PR DESCRIPTION
This pull request adds the functionality to create a edit a study group name from the app. The user can select a Study group and change the name of that Study Group in a modal. The group name is updated in the database and the list is refreshed for the user to see the new changes.